### PR TITLE
Remove useless xargs call from installation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Copy/Paste the snippet below into your terminal. That will save the latest relea
 curl -s https://api.github.com/repos/dotnetcarpenter/install-stripe-cli/tags \
 | jq --raw-output 'sort_by(.name)|last|.commit.sha' \
 | (read sha && echo "https://raw.githubusercontent.com/dotnetcarpenter/install-stripe-cli/$sha") \
-| (read url && xargs sh -c "echo $url/install-stripe-cli-checksums.txt && echo $url/install-stripe-cli") \
+| (read url && sh -c "echo $url/install-stripe-cli-checksums.txt && echo $url/install-stripe-cli") \
 | xargs -P 2 wget -qO;
 b2sum --status -c install-stripe-cli-checksums.txt && chmod +x install-stripe-cli && ./install-stripe-cli --help
 ```


### PR DESCRIPTION
I had to remove that `xargs` call to make it work in my BASH. (`GNU bash, version 3.2.57(1)-release (arm64-apple-darwin21)`)

Are you sure it should be there?